### PR TITLE
Changed .ds directive to .blkb in two files

### DIFF
--- a/ink.asm
+++ b/ink.asm
@@ -12,7 +12,7 @@
 
 app_name:      .db     "ink.bin", 0        ; The executable name, only used in arg1
 max_args:      EQU     16                  ; Maximum number of arguments allowed in argv
-arg_pointer:   .ds     max_args * 3, 0     ; max 16 x 3 bytes each
+arg_pointer:   .blkb   max_args * 3, 0     ; max 16 x 3 bytes each
 num_args:      .db     0                   ; the number of arguments entered
 
 ; ---------------------------------------------

--- a/textinput.asm
+++ b/textinput.asm
@@ -76,13 +76,13 @@ VDUdata:
     .db     "Please enter your name:"  ; print this text
     .db     31, 0, 12                  ; TAB to 10,20
     .db     17, 128+4                  ; background colour
-    .ds     10,32                      ; a line of 10 spaces
+    .blkb   10,32                      ; a line of 10 spaces
     .db     31, 0, 12                  ; TAB to 10,20
 endVDUdata:
 
 answer:         .db "You typed: "
-textBuffer:     .ds 10,0
-lineOfSpaces:   .ds 10,32
+textBuffer:     .blkb 10,0
+lineOfSpaces:   .blkb 10,32
 
 escaped:        .db "You escaped...",0
 


### PR DESCRIPTION
Hi Richard,

Two files in this set are using .ds where really .blkb is a much better fit.
Going forward, the .ds directive will not permit a value as argument, and will just define empty space. If one really wants to define a number of bytes with a value set, .blkb is the best fit.
I've changed both files with just these changes, should assemble with earlier versions of ez80asm just fine